### PR TITLE
Added graphql yoga benchmarks

### DIFF
--- a/benchmarks/yoga-graphql-jit.js
+++ b/benchmarks/yoga-graphql-jit.js
@@ -1,0 +1,22 @@
+const { GraphQLServer } = require("graphql-yoga");
+const { compileQuery } = require("graphql-jit");
+const { createApolloSchema } = require("../lib/schemas/createApolloSchema");
+
+const schema = createApolloSchema();
+
+const cache = {};
+
+const server = new GraphQLServer({
+  schema,
+  middlewares: [
+    ({ source, context }) => {
+      if (!(source in cache)) {
+        const document = parse(source);
+        cache[source] = compileQuery(schema, document);
+      }
+      return cache[source].query({}, context, {});
+    }
+  ]
+});
+
+server.start({ port: 4001, endpoint: "/graphql" });

--- a/benchmarks/yoga-graphql-trace.js
+++ b/benchmarks/yoga-graphql-trace.js
@@ -1,0 +1,7 @@
+const { GraphQLServer } = require("graphql-yoga");
+const { createApolloSchema } = require("../lib/schemas/createApolloSchema");
+const schema = createApolloSchema();
+
+const server = new GraphQLServer({ schema });
+
+server.start({ port: 4001, endpoint: "/graphql", tracing: true });

--- a/benchmarks/yoga-graphql.js
+++ b/benchmarks/yoga-graphql.js
@@ -1,0 +1,7 @@
+const { GraphQLServer } = require("graphql-yoga");
+const { createApolloSchema } = require("../lib/schemas/createApolloSchema");
+const schema = createApolloSchema();
+
+const server = new GraphQLServer({ schema });
+
+server.start({ port: 4001, endpoint: "/graphql" });

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "graphql-jit": "^0.4.2",
     "graphql-tools": "^4.0.6",
     "graphql-upload": "^9.0.0",
+    "graphql-yoga": "^1.18.3",
     "hide-powered-by": "^1.0.0",
     "hsts": "^2.1.0",
     "http-errors": "^1.7.3",


### PR DESCRIPTION
Thought it might be interesting to look at how [graphql-yoga](https://github.com/prisma-labs/graphql-yoga) would perform here :)

EDIT: I can remove the README.md from this PR if that is not needed 

Here are the results from my run:
duration: 5.02s
connections: 5
pipelining: 1

| Server                                                                                                                                                            | Requests/s | Latency | Throughput/Mb |
| :--                                                                                                                                                               | --:        | :-:     | --:           |
| [fastify-REST](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/fastify-REST.js)                                                         | 5993.2     | 0.29    | 47.93         |
| [fastify-gql+graphql-jit](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/fastify-gql+graphql-jit.js)                                   | 5724.4     | 0.29    | 35.66         |
| [express-REST](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/express-REST.js)                                                         | 4692.2     | 0.41    | 37.82         |
| [graphql-api-koa+graphql-jit](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/graphql-api-koa+graphql-jit.js)                           | 2904.6     | 1.31    | 18.09         |
| [fastify-gql](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/fastify-gql.js)                                                           | 2650.6     | 1.39    | 16.51         |
| [express-graphql+graphql-jit](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/express-graphql+graphql-jit.js)                           | 2578.2     | 1.42    | 16.22         |
| [express-graphql+graphql-jit+type-graphql](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/express-graphql+graphql-jit+type-graphql.js) | 2263.8     | 1.60    | 14.25         |
| [yoga-graphql-jit](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/yoga-graphql-jit.js)                                                 | 2215.8     | 1.71    | 0.64          |
| [apollo-server-fastify+graphql-jit](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/apollo-server-fastify+graphql-jit.js)               | 2066.4     | 1.78    | 12.90         |
| [graphql-api-koa](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/graphql-api-koa.js)                                                   | 1810.2     | 2.51    | 11.28         |
| [express-graphql](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/express-graphql.js)                                                   | 1674.6     | 2.64    | 10.54         |
| [yoga-graphql](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/yoga-graphql.js)                                                         | 1614.2     | 2.76    | 10.12         |
| [apollo-schema+async](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/apollo-schema+async.js)                                           | 1612.0     | 2.69    | 10.15         |
| [express-graphql+type-graphql](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/express-graphql+type-graphql.js)                         | 1573.0     | 2.70    | 9.90          |
| [type-graphql+async](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/type-graphql+async.js)                                             | 1507.4     | 2.78    | 9.49          |
| [type-graphql+middleware](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/type-graphql+middleware.js)                                   | 1490.4     | 2.83    | 9.38          |
| [apollo-server-fastify](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/apollo-server-fastify.js)                                       | 1457.0     | 2.92    | 9.10          |
| [type-graphql+async-middleware](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/type-graphql+async-middleware.js)                       | 1451.2     | 2.90    | 9.14          |
| [express-graphql-dd-trace-no-plugin](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/express-graphql-dd-trace-no-plugin.js)             | 1349.4     | 3.09    | 8.49          |
| [apollo-server-express](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/apollo-server-express.js)                                       | 1309.6     | 3.19    | 8.28          |
| [yoga-graphql-trace](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/yoga-graphql-trace.js)                                             | 974.6      | 4.58    | 30.98         |
| [apollo-opentracing](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/apollo-opentracing.js)                                             | 941.2      | 4.71    | 5.95          |
| [apollo-server-express-tracing](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/apollo-server-express-tracing.js)                       | 805.4      | 5.84    | 25.65         |
| [express-graphql-dd-trace-less](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/express-graphql-dd-trace-less.js)                       | 673.4      | 6.88    | 4.24          |
| [express-graphql-dd-trace](https://github.com/benawad/node-graphql-benchmarks/tree/master/benchmarks/express-graphql-dd-trace.js)                                 | 643.4      | 7.27    | 4.05          |
