### PR TITLE
Fix: mercurius+graphql-jit+type-graphql

### DIFF
--- a/benchmarks/mercurius+graphql-jit+type-graphql.js
+++ b/benchmarks/mercurius+graphql-jit+type-graphql.js
@@ -11,6 +11,7 @@ const app = Fastify();
 createTypeGraphQLSchema().then((schema) => {
   app.register(mercurius, {
     schema,
+    jit: 1,
   });
   app.listen(4001);
 });


### PR DESCRIPTION
graphql-jit is in the name of this benchmark but jit isn't set to 1 like the others. Makes a big difference.