### PR TITLE
Fixing apollo-server-fastify

### DIFF
--- a/benchmarks/apollo-server-fastify+graphql-jit.js
+++ b/benchmarks/apollo-server-fastify+graphql-jit.js
@@ -21,5 +21,8 @@ const server = new ApolloServer({
     return cache[source].query({}, context, {});
   },
 });
-app.register(server.createHandler());
-app.listen(4001);
+server.start().then(() => {
+  app.register(server.createHandler());
+  app.listen(4001);
+});
+

--- a/benchmarks/apollo-server-fastify.js
+++ b/benchmarks/apollo-server-fastify.js
@@ -8,5 +8,8 @@ const schema = createApolloSchema();
 const server = new ApolloServer({
   schema,
 });
-app.register(server.createHandler());
-app.listen(4001);
+
+server.start().then(() => {
+  app.register(server.createHandler());
+  app.listen(4001);
+})


### PR DESCRIPTION
Fixing apollo-server-fastify and apollo-server-fastify+graphql-jit by starting the apollo server before creating the handler.

I'm not sure why this happens, but the current apollo server fastify integration uses it aswell

Now it's showing the correct informations and not just zeros:
![image](https://github.com/benawad/node-graphql-benchmarks/assets/62081192/987fb469-ea2b-4321-ae79-c0dff850dc40)
