### PR TITLE
Fix route for Go benchmarks

### DIFF
--- a/other-benchmarks/go-gql/server.go
+++ b/other-benchmarks/go-gql/server.go
@@ -21,8 +21,8 @@ func main() {
 
 	srv := handler.NewDefaultServer(generated.NewExecutableSchema(generated.Config{Resolvers: &graph.Resolver{}}))
 
-	http.Handle("/", playground.Handler("GraphQL playground", "/query"))
-	http.Handle("/query", srv)
+	http.Handle("/", playground.Handler("GraphQL playground", "/graphql"))
+	http.Handle("/graphql", srv)
 
 	log.Printf("connect to http://localhost:%s/ for GraphQL playground", port)
 	log.Fatal(http.ListenAndServe(":"+port, nil))


### PR DESCRIPTION
Hi there 👋 

I was running some of the benchmarks in this repo and it came to my attention that the Go benchmarks were not being executed against the schema.

After the fix, I run the Go benchmarks again and it seems that they're actually quite slow. Running the `apollo-server-express` and `go-graphql` benchmarks on a Macbook 16' M2 Max 32GB with these changes yields the following results:

```
 Both are awesome but apollo-server-express is 55.35% faster than go-graphql
 • apollo-server-express request average is 3336.6
 • go-graphql request average is 2147.81
```